### PR TITLE
[MRG] pin python version to python3.8

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - r-base
+    - r-base=4.0.5
     - r-irkernel=1.1
     - r-devtools
     - snakemake-minimal

--- a/rnaseq-env.yml
+++ b/rnaseq-env.yml
@@ -10,3 +10,4 @@ dependencies:
   - multiqc=1.8
   - salmon=1.4.0
   - tbb=2020.3
+  - python=3.8

--- a/rnaseq-workflow.Rmd
+++ b/rnaseq-workflow.Rmd
@@ -32,29 +32,11 @@ FC_cutoff <- log2(1.1)
 
 
 
-# RNA-Seq Differential Expression Analysis Day 2
-
-**When:** September 27st & 28th from 11:00 am PDT - 1:00 pm PDT/2:00 pm - 4:00 pm EDT
+# RNA-Seq Differential Expression Analysis
 
 **Instructor:** Amanda Charbonneau 
 
-**Helpers:** Jeremy Walter and Saranya Canchi
-
-**Zoom:** https://zoom.us/j/7575820324?pwd=d2UyMEhYZGNiV3kyUFpUL1EwQmthQT09
-
-**Day 1 Notes:** https://hackmd.io/y63ixq2pQg28cMrptElOPQ
-
 <div class="alert alert-success">
-While we wait to get started --
-
-1. Click this button [![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/nih-cfde/rnaseq-in-the-cloud/stable?urlpath=rstudio) to start a virtual machine. It can take up to 20 minutes for them all to start with this many participants so we're going start them and talk about the differential expression (DE) pipeline we're using while they all spin up.
-
-3. ✅ Have you looked at the [pre-workshop resources page](https://github.com/nih-cfde/training-and-engagement/wiki/Resources-for-Workshop-Attendees)?
-
-2. ✏️ Please fill out our pre-workshop survey if you have not already done so! Link here: https://forms.gle/6oesZ7h789xbYLc29
-
-Put up a ✋ on Zoom when you've *clicked* the launch binder link! (It takes a few minutes to load, so we're getting it started before the hands-on activities)
-</div>
 
 
 


### PR DESCRIPTION
this fixes a problem where networkx tries to import `gcd` from `fractions` and not `math`, which doesn't work in python3.9. Rather than upgrading the package as suggested [here](https://www.biostars.org/p/9464708/), I pinned python to 3.8 instead.

cc @ACharbonneau 